### PR TITLE
Clarify note titles in installation guides

### DIFF
--- a/docs/projects/BthPS3/How-to-Install.md
+++ b/docs/projects/BthPS3/How-to-Install.md
@@ -1,9 +1,9 @@
 # How to Install  
 
-## Before You Begin:  
+## Before You Begin
 
-- This set of drivers has been designed for and tested with the original Sony PlayStation **3** peripherals, better known by the names SIXAXIS, DualShock and Navigation controller. If your controller works, great! Take it as a win. However, if it does not, please do not contact support as there is nothing we can do.  
-- Do *not* attempt to pair a PS3 Controller on Windows via the built-in device discovery dialog, like:  
+- This set of drivers has been designed for and tested with the original Sony PlayStation **3** peripherals, better known as the SIXAXIS, DualShock, and Navigation controllers. If your controller works, great—take it as a win. However, if it does not, please do not contact support as there is nothing we can do.
+- Do *not* attempt to pair a PS3 controller on Windows via the built-in device discovery dialog, like:
 ![pairing-fail.png](images/pairing-fail.png)  
 This will **not work** and can cause Bluetooth connection to fail completely.  
 To check if you did, open the Bluetooth Settings page within Windows and check the list for entries similar to:  
@@ -11,26 +11,26 @@ To check if you did, open the Bluetooth Settings page within Windows and check t
 ![explorer_7O9IulBc4C2.png](images/explorer_7O9IulBc4C2.png)  
 If you see this, simply select it and click the "Remove device" button.  
 
-- For the setup to work correctly **Windows UAC needs to be enabled**. If in doubt, the following page has instructions on how to check its status: [link here](https://articulate.com/support/article/how-to-turn-user-account-control-on-or-off-in-windows-10)   
+- For the setup to work correctly **Windows UAC needs to be enabled**. If in doubt, the following page has instructions on how to check its status: [link here](https://articulate.com/support/article/how-to-turn-user-account-control-on-or-off-in-windows-10)
 
-## Installing BthPS3 Drivers:  
+## Installing BthPS3 Drivers
 
-!!! note "Note:" 
-    The following steps are only required if you plan on using your PS3 controller wirelessly over Bluetooth. If you just plan on using a USB cable, then all you need is [DsHidMini](../DsHidMini/index.md).  
+!!! note "Bluetooth setup only"
+    The following steps are only required if you plan on using your PS3 controller wirelessly over Bluetooth. If you just plan on using a USB cable, then all you need is [DsHidMini](../DsHidMini/index.md).
 
-- If you had the DsHidMini installation wizard download the BthPS3 install file for you, you should be able to find it in your "Downloads" folder. It should be named Nefarius_BthPS3_Drivers_x64_arm64_vx.x.x.msi (where the x's represent the current version number). If you didn't (or if for some reason can't find it there), you can download it directly from the official BthPS3 GitHub Releases page [here](https://github.com/nefarius/BthPS3/releases).  
+- If you had the DsHidMini installation wizard download the BthPS3 install file for you, you should be able to find it in your "Downloads" folder. It should be named Nefarius_BthPS3_Drivers_x64_arm64_vx.x.x.msi (where the x's represent the current version number). If you did not (or if for some reason cannot find it there), you can download it directly from the official BthPS3 GitHub Releases page [here](https://github.com/nefarius/BthPS3/releases).
 - Double click on the installation file to start the Installation Wizard, then click "Next".
 ![BthPS3 Wizard](<images/BthPS3 Wizard.png>)  
 - The next screen is the "End-User License Agreement". Read through the agreement and click the box to accept the terms. Then click "Next". 
 ![BthPS3 EULA.png](<images/BthPS3 EULA.png>)  
-- The next screen shows what drivers will be installed.  The "BthPS3 Bluetooth Drivers" and "Open post-installation article" is selected by default.  Leave those checked and click "Next".  
+- The next screen shows what drivers will be installed. The "BthPS3 Bluetooth Drivers" and "Open post-installation article" options are selected by default. Leave those checked and click "Next".
 ![BthPS3 Drivers](<images/BthPS3 Drivers.png>)  
-- The next screen asks if you want to use the the "Modern hot-plug" or "Legacy sequential" method to install the drivers. The modern method does not require you to restart your computer, but doesn't work for all Bluetooth receivers.  The legacy method should always work, but requires you to restart your computer afterwards. For the purposes of this guide, I am using the "Legacy" method. Make your choice, then click "Next".  
+- The next screen asks if you want to use the "Modern hot-plug" or "Legacy sequential" method to install the drivers. The modern method does not require you to restart your computer but does not work for all Bluetooth receivers. The legacy method should always work but requires you to restart your computer afterward. Choose the option that fits your setup, then click "Next".
 ![BthPS3 Method](<images/BthPS3 Method.png>)  
-- The UAC window should pop up asking if you are ok with the wizard making changes to your computer. If you don't see it, check your task bar for a shield icon and click that. After clicking "Yes" the installation wizard will continue.  
+- The UAC window should pop up asking if you are ok with the wizard making changes to your computer. If you don't see it, check your taskbar for a shield icon and click that. After clicking "Yes" the installation wizard will continue.
 ![UAC.png](images/UAC.png)  
-- If using the Legacy Method, you will be told to reboot your computer. Click "OK". (We will restart our computer at the end).  
-![Reboot.png](images/Reboot.png)  
-- After the BthPS3 Drivers have been installed, a webpage will open with some important information. Please read through it. When done, click "Finish" to close the wizard. You can now restart your computer.  
-![BthPS3 Finish](<images/BthPS3 Finish.PNG>)  
-- **Congratulations!!** BthPS3 is now installed! You may now plug in your controller via USB cable which will automatically pair your controller for Bluetooth. Remember, this is the only way you should be pairing your controller.
+- If using the Legacy Method, you will be told to reboot your computer. Click "OK". (You can restart your computer at the end.)
+![Reboot.png](images/Reboot.png)
+- After the BthPS3 Drivers have been installed, a webpage will open with important information. Please read through it. When done, click "Finish" to close the wizard. You can now restart your computer.
+![BthPS3 Finish](<images/BthPS3 Finish.PNG>)
+- **Congratulations!** BthPS3 is now installed. You can plug in your controller via USB, which will automatically pair it for Bluetooth. This is the only way you should be pairing your controller.

--- a/docs/projects/DsHidMini/Experimental/Version-3-Beta.md
+++ b/docs/projects/DsHidMini/Experimental/Version-3-Beta.md
@@ -33,4 +33,4 @@ Version 3 uses a completely different configuration system so the old `DSHMC.exe
 
 ## Removal
 
-Check the dedicated [V3 BETA installation/removal page](../../v3/How-to-Install.md#removal)
+Check the dedicated [V3 BETA installation/removal page](../v3/How-to-Install.md#removal)

--- a/docs/projects/DsHidMini/Experimental/Version-3-Beta.md
+++ b/docs/projects/DsHidMini/Experimental/Version-3-Beta.md
@@ -33,4 +33,4 @@ Version 3 uses a completely different configuration system so the old `DSHMC.exe
 
 ## Removal
 
-Check the dedicated [V3 BETA installation/removal page](../../v3/how-to-install/#removal)
+Check the dedicated [V3 BETA installation/removal page](../../v3/How-to-Install.md#removal)

--- a/docs/projects/DsHidMini/v2/DS4-Mode-User-Guide.md
+++ b/docs/projects/DsHidMini/v2/DS4-Mode-User-Guide.md
@@ -160,6 +160,7 @@ There are 2 modes of Light Bar to LED control: **Simple** and **Complete**. To l
 
     No need to. The "real" part of the DS3 controller in DsHidMini's DS4Windows Mode can only be recognized by DS4Windows and is therefore already immune to the "double controller" or "double input" issue. Games will only be able to detect the DS3's emulated/virtual Xbox 360/DS4 counterpart.
 
+<a id="select-button-is-not-recognized-in-some-games-when-emulating-a-ds4-how-do-i-use-the-touch-pad-button"></a>
 ??? question "_Select button is not recognized in some games when emulating a DS4 / How do I use the Touch Pad button?_"
 
     A DS3 controller has 13 buttons while a real DS4 controller has 14, this extra button being the `Touch Pad` button which can't be mapped directly to the DS3 by DsHidMini.
@@ -176,6 +177,7 @@ There are 2 modes of Light Bar to LED control: **Simple** and **Complete**. To l
 
     If a game uses both the `Share` and `TP` buttons, you can have a profile with `Share` as it is and the `PS` button remapped to the `TP`. Or, if you want more advanced solutions, you can use `special actions` in the profile settings so you can switch between different profiles by button combinations mid-game.
 
+<a id="i-cant-control-steams-big-picture-when-using-a-emulated-ds4-steam-doesnt-detect-my-controller-when-its-emulated-as-a-ds4-only-when-emulated-as-a-xbox-360"></a>
 ??? question " _Steam/Some emulator or app doesn't detect my controller when emulating a DS4, only when emulating a Xbox 360_"
 
     Steam and some other apps/emulators (Yuzu/CEMU) will fully ignore DS4 controllers, real or virtual, if they detect that DS4Windows is running. This happens as their own means of preventing the "double controller" issue, which is not a problem for DS3 controllers being used with DS4Windows.

--- a/docs/projects/DsHidMini/v3/How-to-Install.md
+++ b/docs/projects/DsHidMini/v3/How-to-Install.md
@@ -5,7 +5,7 @@
 !!! danger highlight "DsHidMini V3 BETA installation page!"
     Version 3 is still in BETA. Although tests indicate things are working smoothly, keep in mind that you may encounter unknown issues or missing features.
 
-    Make sure to check the [intro page for the V3 Beta](../) before continuing!
+    Make sure to check the [intro page for the V3 Beta](../index.md) before continuing!
 
 !!! danger highlight "STOP trying to use DsHidMini with random controllers"
     This and **only** this controller (Sony DualShock 3 a.k.a. PS3 Gamepad) is supported:

--- a/docs/projects/DsHidMini/v3/How-to-Install.md
+++ b/docs/projects/DsHidMini/v3/How-to-Install.md
@@ -3,16 +3,16 @@
 ## Things to Know Before You Begin
 
 !!! danger highlight "DsHidMini V3 BETA installation page!"
-    Version 3 is still in BETA. Although all of our tests indicate things are working smoothly, keep in mind that you may encounter unknown issues or features that are missing or yet to be implemented.
+    Version 3 is still in BETA. Although tests indicate things are working smoothly, keep in mind that you may encounter unknown issues or missing features.
 
     Make sure to check the [intro page for the V3 Beta](../) before continuing!
 
 !!! danger highlight "STOP trying to use DsHidMini with random controllers"
-    This and **only** this controller (Sony DualShock 3 a.k.a. PS3 Gamepad) is supported:  
-    ![ds3](images/dualshock-3-resized.png)  
+    This and **only** this controller (Sony DualShock 3 a.k.a. PS3 Gamepad) is supported:
+    ![ds3](images/dualshock-3-resized.png)
     Do NOT contact support for any other device, **it will not work**, no matter how many times you ask!
 
-- DsHidMini was designed to work with Official Sony PS3 DualShock 3 controllers. Most DualShock 3 controllers sold online these days are not original controllers. It can be difficult to tell these fake controllers apart from their original counterparts as they are made with the same molds and have the same symbols and labels on them as official DualShock 3 controllers. These fake controllers might be missing some features (such as motion controls or pressure-sensitive buttons) and most likely will not work with DsHidMini.  If your non-official controller does work, take it as a win.  However, if it does not, please do not contact support as there is nothing we can do.  
+- DsHidMini was designed to work with Official Sony PS3 DualShock 3 controllers. Most DualShock 3 controllers sold online these days are not original controllers. It can be difficult to tell these fake controllers apart from their original counterparts as they are made with the same molds and have the same symbols and labels on them as official DualShock 3 controllers. These fake controllers might be missing some features (such as motion controls or pressure-sensitive buttons) and most likely will not work with DsHidMini. If your non-official controller does work, take it as a win. However, if it does not, please do not contact support as there is nothing we can do.
 
 - **If you want Bluetooth support** you need to [install BthPS3](../../BthPS3/How-to-Install.md). This can be done either before or after installing DsHidMini.
 
@@ -22,56 +22,56 @@
 
 ### Driver Installation
 
-!!! note "NOTE" 
-    
-    Previous versions of DsHidMini required you to uninstall old/outdated software that may cause conflicts.  This is no longer required, so no matter what software you may have preinstalled, the installation steps below are always the same 😀 
+!!! note "No pre-uninstall required"
 
-- Head to the official GitHub page for DsHidMini releases [here](https://github.com/nefarius/DsHidMini/releases). The top of the Releases page should show the latest version, which at the time of this writting is v3.5.1 and is currently listed as a "Pre-Release".  
+    Previous versions of DsHidMini required you to uninstall old or outdated software that may cause conflicts. This is no longer required, so no matter what software you may have preinstalled, the installation steps below are always the same 😀
+
+- Head to the official GitHub page for DsHidMini releases [here](https://github.com/nefarius/DsHidMini/releases). The top of the Releases page shows the latest version, which at the time of writing is v3.5.1 and is currently listed as a "Pre-Release".
 ![Releases.png](images/Releases.png)  
-- Scroll down a bit and click on the word "Assets" and you will see the installation file named "Nefarius_DsHidMini_Drivers_x64_arm64_vx.x.x.msi" (the x's represent the current version number and may be different from the photo below). Click on that name and download the file to your computer.  
+- Scroll down a bit and click on the word "Assets" to see the installation file named "Nefarius_DsHidMini_Drivers_x64_arm64_vx.x.x.msi" (the x's represent the current version number and may be different from the photo below). Click on that name and download the file to your computer.
 ![Assets.png](images/Assets.png)  
-- Double click on the file you downloaded in the previous step which will run the Installation Wizard. Click the "Next" button.  
+- Double click on the file you downloaded in the previous step to run the Installation Wizard. Click the "Next" button.
 ![Installation Wizard.png](<images/Installation Wizard.png>)  
-- The next screen is the "End-User License Agreement". Read through the agreement and click the box to accept the terms.  Then click "Next".  
+- The next screen is the "End-User License Agreement". Read through the agreement and click the box to accept the terms. Then click "Next".
 ![EULA.png](images/EULA.png)  
-- The next screen shows what drivers will be installed.  The "DsHidMini Drivers" is selected by default. This is all you need if you intend to use your PS3 controller while connected to your computer using a USB cable. If you want to to use your controller wirelessly over Bluetooth, then you will have to click the box next to "BthPS3 Wireless Drivers". (Note: this will only download the BthPS3 installation file and will need to be manually run later).  Click next.  
+- The next screen shows what drivers will be installed. The "DsHidMini Drivers" option is selected by default. This is all you need if you intend to use your PS3 controller while connected to your computer using a USB cable. If you want to use your controller wirelessly over Bluetooth, click the box next to "BthPS3 Wireless Drivers". (Note: this only downloads the BthPS3 installation file, which must be run manually later.) Click "Next".
 ![Drivers.png](images/Drivers.png)  
-- The UAC window should pop up asking if you are ok with the wizard making changes to your computer. If you don't see it, check your task bar for a shield icon and click that. After clicking "Yes" the installation wizard will continue.  
+- The UAC window should pop up asking if you are ok with the wizard making changes to your computer. If you don't see it, check your taskbar for a shield icon and click that. After clicking "Yes" the installation wizard will continue.
 ![UAC.png](images/UAC.png)  
-- After the DsHidMini Drivers have been installed, a webpage will open with some important information. Please read through it. When done, click "Next", then "Finish" to close the wizard.  
+- After the DsHidMini Drivers have been installed, a webpage will open with important information. Please read through it. When done, click "Next", then "Finish" to close the wizard.
 ![Finish.png](images/Finish.png)  
 
-**Congratulations!!** Now that [DsHidMini](How-to-Install.md) (and optionally [BthPS3](../../BthPS3/How-to-Install.md)) are installed with the default settings, your controller should be able to work with Windows and behave as if it were an Xbox Controller (Xinput Device). Continue on with the next section to test this.
+**Congratulations!** Now that [DsHidMini](How-to-Install.md) (and optionally [BthPS3](../../BthPS3/How-to-Install.md)) are installed with the default settings, your controller should be able to work with Windows and behave as if it were an Xbox Controller (XInput device). Continue with the next section to test this.
 
 ### Checking Controller with ControlApp.exe  
 
-!!! note "NOTE"
-     ControlApp is a companion application for configuring DsHidMini controllers and does not need to be open for DsHidMini to work. No changes need to be made as the default settings should would just fine.  In this section, it is only being used to verify that DsHidMini is seeing your controller.
+!!! note "ControlApp is optional at runtime"
+    ControlApp is a companion application for configuring DsHidMini controllers and does not need to be open for DsHidMini to work. No changes need to be made, as the default settings should work just fine. In this section, it is only being used to verify that DsHidMini is seeing your controller.
 
-!!! note "NOTE"
-    ControlApp requires the **.NET Desktop Runtime 8** to be able to run. To check whether you already have it, simply try opening the ControlApp.  It will either open normally or prompt you to install [.NET Desktop Runtime 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0).  
+!!! note "ControlApp needs .NET Desktop Runtime 8"
+    ControlApp requires the **.NET Desktop Runtime 8** to run. To check whether you already have it, simply try opening ControlApp. It will either open normally or prompt you to install [.NET Desktop Runtime 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0).
 
-- Connect your PS3 controller to your computer with a USB cable. (Note: This will also automatically pair your controller to your computer for Bluetooth if you installed [BthPS3](../../BthPS3/How-to-Install.md)).
+- Connect your PS3 controller to your computer with a USB cable. (This also automatically pairs your controller to your computer for Bluetooth if you installed [BthPS3](../../BthPS3/How-to-Install.md)).
 - Download the latest version of **ControlApp** from [here](https://buildbot.nefarius.at/builds/DsHidMini/latest/bin/ControlApp.exe)
 - Double click on the newly downloaded **ControlApp.exe**.
-- If you see your controller under "Devices" and it's showing "XInput", then DsHidMini is seeing your controller properly. (If you installed [BthPS3](../../BthPS3/How-to-Install.md), then you can remove your USB cable and see if it shows connected with XInput too).  
+- If you see your controller under "Devices" and it shows "XInput", then DsHidMini is seeing your controller properly. (If you installed [BthPS3](../../BthPS3/How-to-Install.md), remove your USB cable and see if it shows connected with XInput too.)
 ![ControlApp XInput](<images/ControlApp XInput.PNG>)  
 - Close ControlApp and keep it in a convenient location for easy access later.  
 
 ### Testing Your Controller in Windows
 
-- On the lower left corner of your screen where it says "Type here to search" in your task bar, type "joy.cpl", then press ENTER.  
+- On the lower left corner of your screen where it says "Type here to search" in your taskbar, type "joy.cpl", then press ENTER.
 ![Search Bar.png](<images/Search Bar.png>)  
-- This will open the "Game Controllers" control panel window. Connect your PS3 controller to your computer with a USB cable or Bluetooth. You should now see your controller in the list as "DS3 Compatible HID Device" and a Status of "OK". Click on the controller to highlight it, then click "Properties".  
+- This opens the "Game Controllers" control panel window. Connect your PS3 controller to your computer with a USB cable or Bluetooth. You should now see your controller in the list as "DS3 Compatible HID Device" with a Status of "OK". Click on the controller to highlight it, then click "Properties".
 ![USB Conencted.png](<images/USB Connected.png>)  
-- On the next screen, make sure that the "Test" tab is selected. Now move the joysticks and press each button on your controller to see if everything is working. Click "OK" to exit out of the Properties window.  
+- On the next screen, make sure that the "Test" tab is selected. Move the joysticks and press each button on your controller to see if everything is working. Click "OK" to exit the Properties window.
 ![Controller Test.png](<images/Controller Test.png>)  
 
-**Congratulations!!** Your PS3 controller has now been set up and verified working on your computer over USB (and optionally Bluetooth). If it doesn't, try restarting your computer and try again.  If it still doesn't work, then [read on here](How-to-Install.md/#troubleshooting)!  
+**Congratulations!** Your PS3 controller has now been set up and verified working on your computer over USB (and optionally Bluetooth). If it does not, try restarting your computer and try again. If it still does not work, [read on here](How-to-Install.md/#troubleshooting)!
 
-!!! note "NOTE"
-    You can now map your controller in your emulator of choice like you would any other controller. However, to get full controller support in [RPCS3](https://rpcs3.net/) (PS3 emulator) follow this guide [here](RPCS3.md). To get full controller support in [PCSX2](https://pcsx2.net/) (PS2 emulator), follow this guide [here](PCSX2.md).  
-    **Happy Gaming!!**
+!!! note "Map emulators for full support"
+    You can now map your controller in your emulator of choice like you would any other controller. However, to get full controller support in [RPCS3](https://rpcs3.net/) (PS3 emulator) follow this guide [here](RPCS3.md). To get full controller support in [PCSX2](https://pcsx2.net/) (PS2 emulator), follow this guide [here](PCSX2.md).
+    **Happy Gaming!**
 
 ## Updating
 

--- a/docs/projects/DsHidMini/v3/How-to-Install.md
+++ b/docs/projects/DsHidMini/v3/How-to-Install.md
@@ -8,7 +8,7 @@
     Make sure to check the [intro page for the V3 Beta](../index.md) before continuing!
 
 !!! danger highlight "STOP trying to use DsHidMini with random controllers"
-    This and **only** this controller (Sony DualShock 3 a.k.a. PS3 Gamepad) is supported:
+    This and **only** this controller (Sony DualShock 3 a.k.a. PS3 Gamepad) is supported:  
     ![ds3](images/dualshock-3-resized.png)
     Do NOT contact support for any other device, **it will not work**, no matter how many times you ask!
 
@@ -16,7 +16,7 @@
 
 - **If you want Bluetooth support** you need to [install BthPS3](../../BthPS3/How-to-Install.md). This can be done either before or after installing DsHidMini.
 
-- For the setup to work correctly **Windows UAC needs to be enabled**. If in doubt, the following page has instructions on how to check its status: [link here](https://articulate.com/support/article/how-to-turn-user-account-control-on-or-off-in-windows-10)   
+- For the setup to work correctly **Windows UAC needs to be enabled**. If in doubt, the following page has instructions on how to check its status: [link here](https://articulate.com/support/article/how-to-turn-user-account-control-on-or-off-in-windows-10)
 
 ## Installing DsHidMini v3.x.x
 

--- a/docs/projects/DsHidMini/v3/How-to-Install.md
+++ b/docs/projects/DsHidMini/v3/How-to-Install.md
@@ -26,24 +26,24 @@
 
     Previous versions of DsHidMini required you to uninstall old or outdated software that may cause conflicts. This is no longer required, so no matter what software you may have preinstalled, the installation steps below are always the same 😀
 
-- Head to the official GitHub page for DsHidMini releases [here](https://github.com/nefarius/DsHidMini/releases). The top of the Releases page shows the latest version, which at the time of writing is v3.5.1 and is currently listed as a "Pre-Release".
+- Head to the official GitHub page for DsHidMini releases [here](https://github.com/nefarius/DsHidMini/releases). The top of the Releases page shows the latest version, which at the time of writing is v3.5.1 and is currently listed as a "Pre-Release".  
 ![Releases.png](images/Releases.png)  
 - Scroll down a bit and click on the word "Assets" to see the installation file named "Nefarius_DsHidMini_Drivers_x64_arm64_vx.x.x.msi" (the x's represent the current version number and may be different from the photo below). Click on that name and download the file to your computer.
 ![Assets.png](images/Assets.png)  
-- Double click on the file you downloaded in the previous step to run the Installation Wizard. Click the "Next" button.
+- Double click on the file you downloaded in the previous step to run the Installation Wizard. Click the "Next" button.  
 ![Installation Wizard.png](<images/Installation Wizard.png>)  
-- The next screen is the "End-User License Agreement". Read through the agreement and click the box to accept the terms. Then click "Next".
+- The next screen is the "End-User License Agreement". Read through the agreement and click the box to accept the terms. Then click "Next".  
 ![EULA.png](images/EULA.png)  
-- The next screen shows what drivers will be installed. The "DsHidMini Drivers" option is selected by default. This is all you need if you intend to use your PS3 controller while connected to your computer using a USB cable. If you want to use your controller wirelessly over Bluetooth, click the box next to "BthPS3 Wireless Drivers". (Note: this only downloads the BthPS3 installation file, which must be run manually later.) Click "Next".
+- The next screen shows what drivers will be installed. The "DsHidMini Drivers" option is selected by default. This is all you need if you intend to use your PS3 controller while connected to your computer using a USB cable. If you want to use your controller wirelessly over Bluetooth, click the box next to "BthPS3 Wireless Drivers". (Note: this only downloads the BthPS3 installation file, which must be run manually later.) Click "Next".  
 ![Drivers.png](images/Drivers.png)  
-- The UAC window should pop up asking if you are ok with the wizard making changes to your computer. If you don't see it, check your taskbar for a shield icon and click that. After clicking "Yes" the installation wizard will continue.
+- The UAC window should pop up asking if you are ok with the wizard making changes to your computer. If you don't see it, check your taskbar for a shield icon and click that. After clicking "Yes" the installation wizard will continue.  
 ![UAC.png](images/UAC.png)  
-- After the DsHidMini Drivers have been installed, a webpage will open with important information. Please read through it. When done, click "Next", then "Finish" to close the wizard.
+- After the DsHidMini Drivers have been installed, a webpage will open with important information. Please read through it. When done, click "Next", then "Finish" to close the wizard.  
 ![Finish.png](images/Finish.png)  
 
 **Congratulations!** Now that [DsHidMini](How-to-Install.md) (and optionally [BthPS3](../../BthPS3/How-to-Install.md)) are installed with the default settings, your controller should be able to work with Windows and behave as if it were an Xbox Controller (XInput device). Continue with the next section to test this.
 
-### Checking Controller with ControlApp.exe  
+### Checking Controller with `ControlApp.exe`
 
 !!! note "ControlApp is optional at runtime"
     ControlApp is a companion application for configuring DsHidMini controllers and does not need to be open for DsHidMini to work. No changes need to be made, as the default settings should work just fine. In this section, it is only being used to verify that DsHidMini is seeing your controller.
@@ -60,11 +60,11 @@
 
 ### Testing Your Controller in Windows
 
-- On the lower left corner of your screen where it says "Type here to search" in your taskbar, type "joy.cpl", then press ENTER.
+- On the lower left corner of your screen where it says "Type here to search" in your taskbar, type "joy.cpl", then press ENTER.  
 ![Search Bar.png](<images/Search Bar.png>)  
-- This opens the "Game Controllers" control panel window. Connect your PS3 controller to your computer with a USB cable or Bluetooth. You should now see your controller in the list as "DS3 Compatible HID Device" with a Status of "OK". Click on the controller to highlight it, then click "Properties".
+- This opens the "Game Controllers" control panel window. Connect your PS3 controller to your computer with a USB cable or Bluetooth. You should now see your controller in the list as "DS3 Compatible HID Device" with a Status of "OK". Click on the controller to highlight it, then click "Properties".  
 ![USB Conencted.png](<images/USB Connected.png>)  
-- On the next screen, make sure that the "Test" tab is selected. Move the joysticks and press each button on your controller to see if everything is working. Click "OK" to exit the Properties window.
+- On the next screen, make sure that the "Test" tab is selected. Move the joysticks and press each button on your controller to see if everything is working. Click "OK" to exit the Properties window.  
 ![Controller Test.png](<images/Controller Test.png>)  
 
 **Congratulations!** Your PS3 controller has now been set up and verified working on your computer over USB (and optionally Bluetooth). If it does not, try restarting your computer and try again. If it still does not work, [read on here](How-to-Install.md/#troubleshooting)!
@@ -81,8 +81,7 @@ If you want to update, simply [follow the same installation steps](#installing-d
 
 1. The main Beta v3 driver can be removed by just uninstalling `Nefarius DsHidMini Driver` in Windows' Apps & features
 2. BthPS3 can also be uninstalled the same way as above via Apps & Features
-3. The ControlApp companion application isn’t installed in the traditional sense and can be deleted like any other file
-
+3. The ControlApp companion application isn’t installed in the traditional sense and can be deleted like any other file  
 ![ApplicationFrameHost_nFtPcyobyf.png](images/ApplicationFrameHost_nFtPcyobyf.png)
 
 After that, DsHidMini should be fully gone from your computer 😥


### PR DESCRIPTION
## Summary
- clarify the BthPS3 installation note heading to highlight Bluetooth-only steps
- retitle DsHidMini v3 installation notes to summarize their guidance and emulator mapping tips

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6931fcffc0888331beb0108a0f9b938a)