### PR TITLE
Added product-is-busy detection mechanism

### DIFF
--- a/docs/projects/Vicius/Command-Line-Arguments.md
+++ b/docs/projects/Vicius/Command-Line-Arguments.md
@@ -57,6 +57,10 @@ Does nothing if the product is already up to date.
 
 Ignores if the user session is busy and displays the main window if updates were found.
 
+### `--ignore-product-in-use`
+
+Skips the [product-busy detection gate](Local-Configuration.md#productbusydetection) and shows the update notification dialog immediately, even if the watched product is currently running. Has no effect when `productBusyDetection` is not configured.
+
 ### `--log-level <value>`
 
 Alters the default logging level (`info`) to the provided `<value>`.

--- a/docs/projects/Vicius/Exit-Codes.md
+++ b/docs/projects/Vicius/Exit-Codes.md
@@ -18,6 +18,7 @@ Code | Description
 `206` | The [`--purge-postpone`](Command-Line-Arguments.md#-purge-postpone) command finished successfully.
 `207` | A new updater process was successfully created from a temporary location.
 `208` | The updater process was closed while a setup operation was still in progress.
+`209` | The watched product was still running after the maximum wait period ([`productBusyDetection`](Local-Configuration.md#productbusydetection)); nothing was shown or installed. The next scheduled or logon invocation will retry.
 
 ## Error conditions
 

--- a/docs/projects/Vicius/Local-Configuration.md
+++ b/docs/projects/Vicius/Local-Configuration.md
@@ -23,6 +23,7 @@ Field | Type | Description
 `runAsTemporaryCopy` | `bool` | When `true` the updater copies itself to a temporary location before applying the ZIP-based update, so the updater file can be replaced. Useful for portable software distributed as a ZIP. See [ZIP Archives](ZIP-Archives.md).
 `hideRemindButton` | `bool` | When `true` the "Remind me tomorrow" button is hidden from the update notification window, preventing the user from deferring the update.
 `iconBase64` | `string` | Base64-encoded Windows `.ico` data. When set, the updater uses this icon for its window and taskbar entry instead of the built-in default.
+`productBusyDetection` | `object` | When set, the update notification dialog is deferred until none of the configured processes are running. See [Product Busy Detection](#productbusydetection) below.
 
 !!! example "Custom icon"
     Generate a base64 string from your `.ico` file (e.g. with PowerShell: `[Convert]::ToBase64String([IO.File]::ReadAllBytes('icon.ico'))`) and embed it:
@@ -31,6 +32,56 @@ Field | Type | Description
     {
         "shared": {
             "iconBase64": "<base64-encoded .ico data>"
+        }
+    }
+    ```
+
+## `productBusyDetection`
+
+When this optional object is present in the `shared` section, the updater waits for all configured processes to stop running before displaying the update notification dialog. This prevents the dialog from popping up while the user is actively working with the product being updated — a situation where an installation is typically not useful anyway because the product files are in use.
+
+The wait loop is message-pumping rather than a blocking sleep, so the process exits cleanly on logoff or shutdown. If the product is still running after the maximum wait duration the updater exits with code [`209`](Exit-Codes.md) and the next scheduled or logon invocation retries from scratch.
+
+Field | Type | Description | Required
+---|---|---|---
+`imageNames` | `string[]` | Process image base names matched **case-insensitively** against the running process list, e.g. `["MyApp.exe"]`. The updater considers the product in use when **any** of these names matches. | Yes
+`executablePaths` | `string[]` | Optional list of absolute paths (or [Inja templates](Inja-Templates.md)) matched against the full image path of running processes. Useful when multiple unrelated products share the same executable base name. | No
+`pollIntervalSeconds` | `int` | Seconds between successive in-use re-checks. Default: `60`. Minimum enforced by the agent: `5`. | No
+`maxWaitMinutes` | `int` | Maximum minutes to wait before giving up. Default: `180` (3 hours). The agent hard-clamps this value to `180` regardless of what is configured, so the updater process can never run indefinitely. Set to `0` to check once and exit immediately if the product is in use. | No
+
+!!! tip "The feature is opt-in"
+    Deployments that do not set `productBusyDetection` are entirely unaffected. The behavior of the updater is unchanged unless this object is present.
+
+!!! note "Can be overridden on the command line"
+    Passing [`--ignore-product-in-use`](Command-Line-Arguments.md#--ignore-product-in-use) bypasses the gate and shows the dialog immediately regardless of this setting.
+
+!!! note "Interaction with `--terminate-process-before-update`"
+    The product-busy gate is automatically skipped when [`--terminate-process-before-update`](Command-Line-Arguments.md#-terminate-process-before-update-handle) is active, because that mode is designed to kill the product before installation and waiting would be contradictory.
+
+!!! example "Defer while HidHide is running"
+
+    ```json
+    {
+        "shared": {
+            "productBusyDetection": {
+                "imageNames": ["HidHide.exe"],
+                "pollIntervalSeconds": 60,
+                "maxWaitMinutes": 180
+            }
+        }
+    }
+    ```
+
+!!! example "Match by full path using an Inja template"
+
+    ```json
+    {
+        "shared": {
+            "productBusyDetection": {
+                "imageNames": ["MyApp.exe"],
+                "executablePaths": ["{{ env[\"ProgramFiles\"] }}\\Contoso\\MyApp\\MyApp.exe"],
+                "pollIntervalSeconds": 30
+            }
         }
     }
     ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for a new command-line option that can bypass the in-use check and show the update prompt immediately.
  * Documented a new optional setting for delaying update prompts until selected running processes are no longer active.
  * Expanded exit-code documentation with a new status for cases where the app keeps running past the maximum wait time and will retry later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->