### PR TITLE
Update Terminate-Process-before-Update.md

### DIFF
--- a/docs/projects/Vicius/Terminate-Process-before-Update.md
+++ b/docs/projects/Vicius/Terminate-Process-before-Update.md
@@ -1,26 +1,78 @@
 # Process Termination on Update
 
-If the user chooses to install an update, the updater will terminate the specified process if [`--terminate-process-before-update <handle>`](Command-Line-Arguments.md#-terminate-process-before-update-handle) is passed on the command line; this is intended for when the updater is launched by the product that is being updated.
+When the user accepts an update, the setup executable needs to overwrite files that belong to the product — files that are typically locked by the product process while it is running. Passing [`--terminate-process-before-update <handle>`](Command-Line-Arguments.md#-terminate-process-before-update-handle) on the command line instructs the updater to forcefully kill that process right before the setup payload runs (i.e. after the user confirms, but before the installer or ZIP extraction begins).
 
-This handle:
+This is the intended pattern when the updater is launched directly **by** the product it governs.
 
-- **MUST** be a Win32 `HANDLE`
-- **MUST** have `PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION` permissions
-- **MUST** be inheritable, and owned by the updaters' parent process
-- **MUST NOT** be a pseudo-handle, e.g. you can not directly use the return value of `GetCurrentProcess()`
+!!! note "Interaction with productBusyDetection"
+    When a termination handle is configured the [`productBusyDetection`](Local-Configuration.md#productbusydetection) wait gate is skipped entirely. The updater will not wait for the process to exit on its own — it will forcefully terminate it instead.
 
-For example, you can create the handle with:
+## Handle requirements
+
+The value passed to `--terminate-process-before-update` is a Win32 `HANDLE` expressed as a **decimal integer**. The updater validates the handle at startup and silently disables the feature (logging an error) for any of the following:
+
+- **MUST** be a real Win32 `HANDLE` — a **PID is not a handle**. If you only have a PID, obtain a handle first with `OpenProcess()`.
+- **MUST** have `PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION` permissions — `PROCESS_QUERY_LIMITED_INFORMATION` is required because the updater calls `GetProcessId()` on the handle to validate it.
+- **MUST** be inheritable (`bInheritHandle = TRUE`) and owned by the updater's parent process.
+- **MUST NOT** be a pseudo-handle (e.g. the raw return value of `GetCurrentProcess()`). Pseudo-handles are per-process constants whose numeric values are meaningless in any other process. The updater explicitly rejects them.
+
+## Step 1 — Create a real, inheritable handle
+
+Use `DuplicateHandle` to turn the `GetCurrentProcess()` pseudo-handle into a real, inheritable handle that refers to the calling process itself:
 
 ```c++
-HANDLE handle {};
+HANDLE handle{};
 DuplicateHandle(
-    GetCurrentProcess(),
-    GetCurrentProcess(),
-    GetCurrentProcess(),
+    GetCurrentProcess(),   // source process  (us)
+    GetCurrentProcess(),   // source handle   (pseudo-handle to duplicate)
+    GetCurrentProcess(),   // target process  (us — we keep the new handle)
     &handle,
     PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION,
-    /* inheritable = */ true,
-    /* flags = */ 0);
+    /* bInheritHandle = */ TRUE,
+    /* dwOptions     = */ 0);
 ```
 
-You must also specify that handles are inherited when calling `CreateProcess()` to launch the updater.
+All three process arguments are `GetCurrentProcess()` because the product and the updater are started from the same process: we are duplicating our own pseudo-handle into a real, inheritable one that the child updater process will receive via handle inheritance.
+
+!!! important "Close the handle if you do not launch the updater"
+    `DuplicateHandle` allocates a kernel object. If you create the handle but then decide not to launch the updater, call `CloseHandle(handle)` to avoid a handle leak.
+
+## Step 2 — Build the command line
+
+The inherited handle keeps the same numeric value inside the child process. The updater parses the argument as a **decimal integer**, so stringify the handle value accordingly before appending it to the command line:
+
+```c++
+std::wstring cmdLine = LR"("C:\Path\manufacturer_product_Updater.exe")";
+cmdLine += L" --silent-update";
+cmdLine += L" --terminate-process-before-update ";
+cmdLine += std::to_wstring(reinterpret_cast<uintptr_t>(handle));
+```
+
+## Step 3 — Launch the updater with handle inheritance enabled
+
+Pass `bInheritHandles = TRUE` to `CreateProcessW` so the operating system copies all inheritable handles — including the one created above — into the child process:
+
+```c++
+STARTUPINFOW si{ sizeof(si) };
+PROCESS_INFORMATION pi{};
+CreateProcessW(
+    nullptr,          // lpApplicationName  (use cmdLine instead)
+    cmdLine.data(),   // lpCommandLine
+    nullptr,          // lpProcessAttributes
+    nullptr,          // lpThreadAttributes
+    /* bInheritHandles = */ TRUE,
+    0,                // dwCreationFlags
+    nullptr,          // lpEnvironment
+    nullptr,          // lpCurrentDirectory
+    &si,
+    &pi);
+```
+
+## Behavior and failure
+
+!!! warning "Termination is forceful and asynchronous"
+    The updater calls `TerminateProcess(handle, 0)` immediately before running the setup. This is an unconditional, hard kill — the target process receives no shutdown messages, open files may not be flushed, and unsaved user data can be lost. Where practical, save state and close cleanly yourself before launching the updater.
+
+    `TerminateProcess` returns before the process has fully exited. The operating system does not guarantee that all file handles held by the process are released by the time the setup starts. If the setup fails due to locked files immediately after termination, a brief wait or retry in the installer itself is the appropriate remedy.
+
+If the `TerminateProcess` call fails for any reason, the updater aborts the update and exits with code [`111`](Exit-Codes.md).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the updater guide for `--terminate-process-before-update` with a clearer step-by-step workflow.
  * Added details on required handle format, inheritance, permissions, and what happens when an invalid handle is provided.
  * Included explicit setup steps and updated behavior notes for process termination, file-lock timing, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->