### PR TITLE
Full Vicius Docs Sync

### DIFF
--- a/docs/projects/Vicius/Command-Line-Arguments.md
+++ b/docs/projects/Vicius/Command-Line-Arguments.md
@@ -39,7 +39,7 @@ Skips the self-update procedure, even if a newer version is available.
 
 ### `--silent`
 
-Suppresses any UI interaction, even when updates are found.
+Suppresses TaskDialog popups (error messages, "up to date" notices, and UAC prompts). The main update notification window is **still shown** if updates are found. For a fully headless run that also performs the download and install without any UI, use [`--silent-update`](#--silent-update) instead.
 
 Check the app [exit code](Exit-Codes.md) for status details.
 
@@ -55,7 +55,7 @@ Does nothing if the product is already up to date.
 
 ### `--ignore-busy-state`
 
-Ignores if the user session is busy and displays the main window if updates were found.
+Ignores if the user session is busy and displays the main window if updates were found. This flag is only relevant in silent modes (`--background`, `--autostart`, `--silent`, `--silent-update`), because interactive runs always show the window regardless of session state.
 
 ### `--ignore-product-in-use`
 
@@ -132,7 +132,7 @@ Overrides the [detected local product version](Product-Detection.md). This value
 
 Activates a client-side hardened verification mode. Has three effects:
 
-1. **Checksum required** — if the selected release does not provide a `checksum` field in the [remote configuration](Remote-Configuration.md), the update is rejected immediately (exit code `115`).
+1. **Checksum required** — if the selected release does not provide a `checksum` field in the [remote configuration](Remote-Configuration.md), the update is rejected after download with exit code `116`.
 2. **Server cannot downgrade security** — the signature verification settings (`signatureVerificationMode`, `signaturePolicy`, `signatureStrategy`, `signatureConfig`) from the server's `shared` section are ignored. Only values already present in the local configuration or baked into the build apply.
 3. **Minimum security floor** — if the merged `signatureVerificationMode` is `WhenPresent` or `Disabled`, it is silently upgraded to `Required`; if `signaturePolicy` is `Relaxed`, it is upgraded to `Strict`.
 
@@ -154,6 +154,9 @@ Tells the updater it's run by Task Scheduler. It will not display any UI except 
 ### `--temporary`
 
 Tells the updater it's run as a temporary child process to avoid blocking an in-progress setup procedure by locking the origin file. If this flag is present, certain commands (like `--install`) are ignored.
+
+!!! warning "Incompatible with silent-mode flags"
+    Combining `--temporary` with any silent-mode flag (`--silent`, `--background`, `--autostart`, or `--silent-update`) is not supported. The updater will abort at startup and exit with code `112`.
 
 ## Self-Updater
 
@@ -182,7 +185,10 @@ The expected hash digest (lowercase hex string) of the downloaded updater binary
 
 ### `--checksum-alg <value>`
 
-The hashing algorithm to use when verifying `--checksum`. Possible values: `MD5`, `SHA1`, `SHA256`. Defaults to `sha256` when omitted.
+The hashing algorithm to use when verifying `--checksum`. Possible values: `SHA256`, `SHA1`. Defaults to `SHA256` when omitted.
+
+!!! warning "MD5 not supported by the self-updater"
+    Although the main updater supports `MD5` for release checksums, the self-updater module only accepts `SHA256` and `SHA1`. Specifying `MD5` for `latestChecksum` in the remote configuration will cause self-updater verification to fail.
 
 ### `--mirror-url <url>`
 

--- a/docs/projects/Vicius/Common-Errors.md
+++ b/docs/projects/Vicius/Common-Errors.md
@@ -16,7 +16,7 @@ If the connection is blocked, an error message similar to...
 
 ![nefarius_HidHide_Updater_5r14wNiMDp.png](images/nefarius_HidHide_Updater_5r14wNiMDp.png)
 
-...might appear and needs to be rectified by the user (or the setup package the updater is bundled with).
+...might appear and needs to be rectified by the user (or the setup package the updater is bundled with). When the server request fails entirely, the process exits with code `104`.
 
 If the source of the update setup file is blocked, you will end up with a view similar to this after the retries and timeouts have been exhausted:
 
@@ -26,10 +26,17 @@ If the source of the update setup file is blocked, you will end up with a view s
 
 ![Updater_O32X4ghzfb.png](images/Updater_O32X4ghzfb.png)
 
-This error can pop up when the updater is run without any silent switches and neither the server nor the local configuration file provided any details on how to detect the version of the product it watches over.
+This error can pop up when the updater is run without any silent switches and neither the server nor the local configuration file provided any details on how to detect the version of the product it watches over. The process exits with code `105`.
 
 ## Updater process module hash mismatch
 
 ![contoso_EmergencyUrl_Updater_4i9Krd4eBy.png](images/contoso_EmergencyUrl_Updater_4i9Krd4eBy.png)
 
-This error indicates that the updater was called with the [`--temporary`](Command-Line-Arguments.md#-temporary) flag outside of supported operation. I told you to not fiddle with it and that's what you get for being nosey 😆
+This error is a security check that fires when the updater is running as a temporary child process (`--temporary`) and detects that the SHA-256 hash of the parent executable does not match its own. This check exists to prevent an impostor process from loading the updater as a trusted helper. The `--temporary` flag itself is a supported internal mechanism used by the `runAsTemporaryCopy` feature — this dialog means the parent process is not the same binary that spawned the child, which indicates a configuration or security problem.
+
+!!! note "Other incompatible flag combinations"
+    Combining `--temporary` with any silent-mode flag (`--silent`, `--background`, `--autostart`, `--silent-update`) is not supported and causes the updater to abort at startup with exit code `112`.
+
+## Signature or checksum verification failed
+
+When a post-download integrity or authenticity check fails (checksum mismatch, invalid Authenticode chain, publisher pin mismatch, or a missing checksum when `--strict-verification` is active), the updater exits with code `116`. All of these failure types currently share this exit code — see [Exit Codes](Exit-Codes.md#reserved--not-yet-individually-emitted) for details on the reserved granular codes.

--- a/docs/projects/Vicius/Download-Integrity.md
+++ b/docs/projects/Vicius/Download-Integrity.md
@@ -36,7 +36,7 @@ The comparison is **case-insensitive**.
 !!! warning "Algorithm recommendations"
     Prefer `SHA256` for new configurations. `MD5` and `SHA1` are provided for compatibility but are not collision-resistant; they should not be used in security-sensitive environments.
 
-If the computed hash does not match the expected value, the download is rejected and the update fails with exit code `115`.
+If the computed hash does not match the expected value, the download is rejected and the update fails with exit code `116`.
 
 ## Self-updater checksum
 
@@ -57,14 +57,21 @@ You can also protect the self-updater binary download. Add a `latestChecksum` fi
 
 The self-updater module receives this value and verifies the downloaded binary before swapping it for the running updater.
 
+!!! warning "Algorithm support differs for self-updater"
+    The self-updater module only accepts `SHA256` and `SHA1` for `latestChecksum`. Specifying `MD5` will cause self-updater integrity verification to fail. If `latestChecksum` is absent entirely, the self-updater falls back to Authenticode verification only.
+
+## Detection checksum
+
+The `detectionChecksum` field on a release object is separate from the download `checksum`. It is used by the [`FileChecksum` product detection method](Product-Detection.md#filechecksum) to determine whether the locally installed version matches the release, and has no effect on download integrity.
+
 ## Strict mode
 
-When the updater is invoked with [`--strict-verification`](Command-Line-Arguments.md#--strict-verification), a release that does not provide a `checksum` object is **rejected immediately** — even before the download begins. This enforces checksum presence as a policy requirement.
+When the updater is invoked with [`--strict-verification`](Command-Line-Arguments.md#--strict-verification), a release that does not provide a `checksum` object is rejected **after download**, during the integrity check phase. This enforces checksum presence as a policy requirement. The rejection exits with code `116`.
 
 ## Related exit codes
 
 Code | Description
 ---|---
-`115` | Checksum mismatch — the computed hash of the downloaded file does not match the expected value.
+`116` | All post-download integrity/authenticity failures, including checksum mismatch and (when `--strict-verification` is active) a missing `checksum` field.
 
 See [Exit Codes](Exit-Codes.md) for the full list.

--- a/docs/projects/Vicius/Emergency-Feature.md
+++ b/docs/projects/Vicius/Emergency-Feature.md
@@ -15,7 +15,7 @@ In your server-side configuration add the following snippet with a URL of your c
     }
     ```
 
-No matter if the local software is up to date; if the `emergencyUrl` value is set on the server, it will get opened on the client as soon as the next check-cycle is run via Task Scheduler (or during user logon).
+No matter if the local software is up to date; if the `emergencyUrl` value is set on the server, it will be opened on the client on **every successful server response** — including interactive and manual runs, not only scheduled Task Scheduler or logon invocations. The URL is opened via `ShellExecuteA` (default browser or handler) immediately after the server response is processed, before any self-update, product-version, or update-installation logic runs.
 
 !!! danger "This is a powerful mechanism, do not abuse it!"
     Obviously your users will not shower you with praise if you push a random URL on them every day; only set this value if you have a good, unavoidable reason to do so! You have been warned ❤

--- a/docs/projects/Vicius/Exit-Codes.md
+++ b/docs/projects/Vicius/Exit-Codes.md
@@ -17,8 +17,10 @@ Code | Description
 `205` | The user postponed the update and 24 hours since then haven't yet passed.
 `206` | The [`--purge-postpone`](Command-Line-Arguments.md#-purge-postpone) command finished successfully.
 `207` | A new updater process was successfully created from a temporary location.
-`208` | The updater process was closed while a setup operation was still in progress.
-`209` | The watched product was still running after the maximum wait period ([`productBusyDetection`](Local-Configuration.md#productbusydetection)); nothing was shown or installed. The next scheduled or logon invocation will retry.
+`209` | The watched product was still running after the maximum wait period ([`productBusyDetection`](Local-Configuration.md#productbusydetection)); nothing was shown or installed. The next scheduled or logon invocation will retry. Also returned when a logoff or shutdown arrives during the wait.
+
+!!! note "Exit code 208 is reserved"
+    `208` (`NV_S_CLOSED_WHILE_UPDATER_RUNNING`) is defined as a constant but is not currently returned as a process exit code. It is used internally as a setup-task result sentinel. Setups that are interrupted due to user cancellation or process exit report via `109` instead.
 
 ## Error conditions
 
@@ -28,19 +30,25 @@ Code | Description
 `101` | Failed to register autostart entry.
 `102` | Failed to (re-)create scheduled task.
 `103` | Failed to extract self-updater component.
-`104` | Failed to request or process update server response.
+`104` | Failed to request or process the update server response. Also returned when the manifest Ed25519 signature is invalid or the manifest `.minisig` sidecar could not be fetched, or when a manifest version rollback is detected (see [Signature Verification](Signature-Verification.md)).
 `105` | Failed to detect installed product version.
-`106` | The user is currently running a game or other full-screen applications.
-`107` | The release download failed and the user aborted the update.
-`108` | The setup launch failed and the user aborted the update.
-`109` | The setup execution finished with a non-success exit code and the user aborted the update.
-`110` | The [`--purge-postpone`](Command-Line-Arguments.md#-purge-postpone) command didn't succeed. There might be no active postpone period.
-`111` | Failed to terminate the process specified via [`--terminate-process-before-update`](Command-Line-Arguments.md#-terminate-process-before-update-handle).
-`112` | Two or more specified [command line arguments](Command-Line-Arguments.md) were incompatible with each other.
+`106` | The user session is currently busy (e.g. a full-screen game or presentation is running) and the updater is running in a silent mode. This check is only performed in silent runs (`--background`, `--autostart`, `--silent`, `--silent-update`); interactive runs always show the window regardless of session state.
+`107` | The release download failed (network error, timeout, or all retries exhausted).
+`108` | The setup process could not be launched (e.g. the downloaded file is missing or cannot be executed).
+`109` | The setup process exited with a non-success exit code, or a setup launch/extraction error occurred. Also returned when the `--terminate-process-before-update` call fails (see below).
+`110` | The [`--purge-postpone`](Command-Line-Arguments.md#-purge-postpone) command encountered a registry error. An empty or absent postpone entry is not an error — the command exits `206` in that case.
+`112` | Two or more specified [command line arguments](Command-Line-Arguments.md) were incompatible with each other. Currently this only occurs when `--temporary` is combined with any silent-mode flag (`--silent`, `--background`, `--autostart`, or `--silent-update`).
 `113` | The updater file name contains some invalid sequences.
 `114` | Failed to create the Direct3D 11 rendering device (display driver issue or insufficient GPU).
-`115` | Checksum failure — either the release was rejected before download because it lacks a `checksum` field when [`--strict-verification`](Command-Line-Arguments.md#--strict-verification) is active, or the computed hash of the downloaded file does not match the expected value. See [Download Integrity](Download-Integrity.md).
-`116` | Setup Authenticode signature is invalid or the chain could not be validated. See [Signature Verification](Signature-Verification.md).
-`117` | Publisher certificate does not match the configured pin. See [Signature Verification](Signature-Verification.md).
-`118` | Manifest Ed25519 signature is invalid or the `.minisig` sidecar could not be fetched. See [Signature Verification](Signature-Verification.md).
-`119` | Manifest version rollback detected — the server delivered an older manifest version. See [Signature Verification](Signature-Verification.md).
+`116` | A post-download integrity or authenticity check failed. This covers all of: checksum mismatch, invalid or untrusted Authenticode chain, publisher certificate not matching the configured pin, and (when `--strict-verification` is active) a release that lacks a required `checksum` field. See [Signature Verification](Signature-Verification.md) and [Download Integrity](Download-Integrity.md).
+
+!!! note "Reserved / not yet individually emitted"
+    The following codes are defined in the source but currently all map to `116` (post-download) or `104` (manifest) or `109` (terminate-process) at runtime:
+
+    Code | Reserved meaning
+    ---|---
+    `111` | Failed to terminate the process specified via [`--terminate-process-before-update`](Command-Line-Arguments.md#-terminate-process-before-update-handle). Currently reported as `109`.
+    `115` | Checksum mismatch (download hash differs from expected value). Currently reported as `116`.
+    `117` | Publisher certificate does not match the configured pin. Currently reported as `116`.
+    `118` | Manifest Ed25519 signature invalid or sidecar not fetchable. Currently reported as `104`.
+    `119` | Manifest version rollback detected. Currently reported as `104`.

--- a/docs/projects/Vicius/Local-Configuration.md
+++ b/docs/projects/Vicius/Local-Configuration.md
@@ -10,12 +10,12 @@ For example, having our updater called `nefarius_HidHide_Updater.exe` it will lo
 
 ## Notable `shared` fields
 
-The `shared` section accepts a number of fields that influence how the updater behaves and is presented. The most commonly needed ones are listed here; all are optional.
+The `shared` section accepts a number of fields that influence how the updater behaves and is presented. All are optional.
 
 Field | Type | Description
 ---|---|---
-`windowTitle` | `string` | Window title shown in the taskbar.
-`productName` | `string` | Product name shown in the UI (e.g. "Updates for **My Product** are available").
+`windowTitle` | `string` | Window title shown in the taskbar. Default: `"Nefarius' Updater"`.
+`productName` | `string` | Product name shown in the UI (e.g. "Updates for **My Product** are available"). Default: `"Updater"`.
 `detectionMethod` | `string` | The [product detection method](Product-Detection.md) to use.
 `detection` | `object` | Parameters for the chosen detection method.
 `installationErrorUrl` | `string` | URL opened in the browser when an installation fails, so the user can find further guidance.
@@ -24,6 +24,10 @@ Field | Type | Description
 `hideRemindButton` | `bool` | When `true` the "Remind me tomorrow" button is hidden from the update notification window, preventing the user from deferring the update.
 `iconBase64` | `string` | Base64-encoded Windows `.ico` data. When set, the updater uses this icon for its window and taskbar entry instead of the built-in default.
 `productBusyDetection` | `object` | When set, the update notification dialog is deferred until none of the configured processes are running. See [Product Busy Detection](#productbusydetection) below.
+`signatureVerificationMode` | `string` | Controls whether the Authenticode signature of the downloaded setup is checked. Possible values: `Disabled`, `WhenPresent` (default), `Required`. See [Signature Verification](Signature-Verification.md).
+`signaturePolicy` | `string` | Controls whether the signing certificate identity must match a configured pin once the Authenticode chain is valid. Possible values: `Relaxed` (default), `Strict`. See [Signature Verification](Signature-Verification.md).
+`signatureStrategy` | `string` | When `signaturePolicy` is `Strict`, controls where the expected certificate identity comes from. Possible values: `FromUpdaterBinary` (default), `FromConfiguration`. See [Signature Verification](Signature-Verification.md).
+`signatureConfig` | `object` | Explicit certificate pin fields used with the `FromConfiguration` strategy. See [Signature Verification](Signature-Verification.md) for available fields.
 
 !!! example "Custom icon"
     Generate a base64 string from your `.ico` file (e.g. with PowerShell: `[Convert]::ToBase64String([IO.File]::ReadAllBytes('icon.ico'))`) and embed it:
@@ -40,11 +44,11 @@ Field | Type | Description
 
 When this optional object is present in the `shared` section, the updater waits for all configured processes to stop running before displaying the update notification dialog. This prevents the dialog from popping up while the user is actively working with the product being updated — a situation where an installation is typically not useful anyway because the product files are in use.
 
-The wait loop is message-pumping rather than a blocking sleep, so the process exits cleanly on logoff or shutdown. If the product is still running after the maximum wait duration the updater exits with code [`209`](Exit-Codes.md) and the next scheduled or logon invocation retries from scratch.
+The wait loop is message-pumping rather than a blocking sleep, so the process exits cleanly on logoff or shutdown. If the product is still running after the maximum wait duration, **or** if a logoff/shutdown signal is received while waiting, the updater exits with code [`209`](Exit-Codes.md) and the next scheduled or logon invocation retries from scratch.
 
 Field | Type | Description | Required
 ---|---|---|---
-`imageNames` | `string[]` | Process image base names matched **case-insensitively** against the running process list, e.g. `["MyApp.exe"]`. The updater considers the product in use when **any** of these names matches. | Yes
+`imageNames` | `string[]` | Process image base names matched **case-insensitively** against the running process list, e.g. `["MyApp.exe"]`. The updater considers the product in use when **any** of these names matches. | No (but at least one of `imageNames` or `executablePaths` should be provided for the detection to be meaningful)
 `executablePaths` | `string[]` | Optional list of absolute paths (or [Inja templates](Inja-Templates.md)) matched against the full image path of running processes. Useful when multiple unrelated products share the same executable base name. | No
 `pollIntervalSeconds` | `int` | Seconds between successive in-use re-checks. Default: `60`. Minimum enforced by the agent: `5`. | No
 `maxWaitMinutes` | `int` | Maximum minutes to wait before giving up. Default: `180` (3 hours). The agent hard-clamps this value to `180` regardless of what is configured, so the updater process can never run indefinitely. Set to `0` to check once and exit immediately if the product is in use. | No
@@ -79,12 +83,37 @@ Field | Type | Description | Required
         "shared": {
             "productBusyDetection": {
                 "imageNames": ["MyApp.exe"],
-                "executablePaths": ["{{ env[\"ProgramFiles\"] }}\\Contoso\\MyApp\\MyApp.exe"],
+                "executablePaths": ["{{ envar(\"ProgramFiles\") }}\\Contoso\\MyApp\\MyApp.exe"],
                 "pollIntervalSeconds": 30
             }
         }
     }
     ```
+
+    Use the `envar(name)` callback to read environment variables inside inja templates. The `env[name]` bracket syntax is not available in this context. See [Inja Templates](Inja-Templates.md) for the full list of available callbacks.
+
+## Notable `instance` fields
+
+The `instance` section configures the updater's own behavior (server URL, network settings, etc.). All fields are optional unless stated otherwise.
+
+Field | Type | Description
+---|---|---
+`serverUrlTemplate` | `string` | The URL or URL template used to fetch the remote configuration. `{}` is replaced with `manufacturer/product` (or `manufacturer/product/channel` when a channel is set). See [Server Discovery](Server-Discovery.md).
+`fallbackServerUrlTemplates` | `string[]` | Additional URLs tried in order if the primary `serverUrlTemplate` request fails.
+`filenameRegex` | `string` | Regular expression used to extract the `manufacturer` and `product` from the updater executable name. Default: `^(\w+)_(\w+)_Updater.*?`. Override this if your executable uses a different naming convention.
+`channel` | `string` | Update channel name inserted into the server URL template as the third path segment. Can also be supplied via [`--channel`](Command-Line-Arguments.md#--channel-value) on the command line.
+`authority` | `string` | Controls which configuration source wins for overlapping `shared` fields. Possible values: `Remote` (default), `Local`. See [Authority](#authority-field) below.
+`network` | `object` | Network and proxy settings. See the table below.
+
+### `network` fields
+
+Field | Type | Description
+---|---|---
+`proxyMode` | `string` | How the updater selects a proxy. Possible values: `System` (default — use the system proxy), `None` (direct connection, no proxy), `Custom` (use `proxyUrl`).
+`proxyUrl` | `string` | Explicit HTTP proxy URL (e.g. `http://proxy.corp:8080`). Only used when `proxyMode` is `Custom`.
+`dohUrl` | `string` | DNS-over-HTTPS resolver URL. When set, DNS lookups use this resolver instead of the system default.
+`ipFamily` | `string` | IP version preference. Possible values: `Any` (default), `IPv4`, `IPv6`.
+`pinnedHosts` | `object[]` | List of host-pin entries for certificate pinning on specific hosts.
 
 ## `Authority` field
 

--- a/docs/projects/Vicius/Local-Configuration.md
+++ b/docs/projects/Vicius/Local-Configuration.md
@@ -101,7 +101,7 @@ Field | Type | Description
 `serverUrlTemplate` | `string` | The URL or URL template used to fetch the remote configuration. `{}` is replaced with `manufacturer/product` (or `manufacturer/product/channel` when a channel is set). See [Server Discovery](Server-Discovery.md).
 `fallbackServerUrlTemplates` | `string[]` | Additional URLs tried in order if the primary `serverUrlTemplate` request fails.
 `filenameRegex` | `string` | Regular expression used to extract the `manufacturer` and `product` from the updater executable name. Default: `^(\w+)_(\w+)_Updater.*?`. Override this if your executable uses a different naming convention.
-`channel` | `string` | Update channel name inserted into the server URL template as the third path segment. Can also be supplied via [`--channel`](Command-Line-Arguments.md#--channel-value) on the command line.
+`channel` | `string` | Update channel name inserted into the server URL template as the third path segment. It can also be supplied via [`--channel`](Command-Line-Arguments.md#--channel-value) on the command line.
 `authority` | `string` | Controls which configuration source wins for overlapping `shared` fields. Possible values: `Remote` (default), `Local`. See [Authority](#authority-field) below.
 `network` | `object` | Network and proxy settings. See the table below.
 

--- a/docs/projects/Vicius/Logging.md
+++ b/docs/projects/Vicius/Logging.md
@@ -4,13 +4,13 @@ Anything that can go wrong will at some point go wrong. When that happens, the u
 
 ## Default log level
 
-The default log level is **`info`**. Debug and trace messages (including output from the `log()` callback in [Inja templates](Inja-Templates.md)) require explicitly raising the level to `debug` or lower via [`--log-level debug`](Command-Line-Arguments.md#-log-level-value).
+The default log level is **`info`**. Debug messages (including output from the `log()` callback in [Inja templates](Inja-Templates.md)) require [`--log-level debug`](Command-Line-Arguments.md#-log-level-value); trace messages require `--log-level trace`.
 
 ## Observing logs
 
 To observe the live `OutputDebugString` output I recommend using the tool [DebugView++](https://github.com/CobaltFusion/DebugViewPP) since it offers nice filtering options and other convenience features.
 
-Alternatively, you can also enable [logging to file](Command-Line-Arguments.md#-log-to-file-value) to persist the output, or [raise the log level](Command-Line-Arguments.md#-log-level-value) to get more details.
+Alternatively, you can also enable [logging to file](Command-Line-Arguments.md#-log-to-file-value) to persist the output, or [select a more verbose log level](Command-Line-Arguments.md#-log-level-value) to get more details.
 
 ## Examples
 

--- a/docs/projects/Vicius/Logging.md
+++ b/docs/projects/Vicius/Logging.md
@@ -1,10 +1,16 @@
 # Logging
 
-Anything that can go wrong will at some point go wrong. When that happens, the updater provides you with a ton of information via [debug logging](https://learn.microsoft.com/en-us/windows/win32/api/debugapi/nf-debugapi-outputdebugstringa), which is always on by default (can be disabled on compilation though; set `NV_FLAGS_NO_LOGGING` in `CustomizeMe.h`).
+Anything that can go wrong will at some point go wrong. When that happens, the updater provides detailed information via [debug output](https://learn.microsoft.com/en-us/windows/win32/api/debugapi/nf-debugapi-outputdebugstringa) using an MSVC/OutputDebugString sink. Logging is enabled by default and can be disabled at compile time by setting `NV_FLAGS_NO_LOGGING` in `CustomizeMe.h` (it is commented out in the default build, so logging is active unless you explicitly opt out).
 
-To observe the live logs I recommend using the tool [DebugView++](https://github.com/CobaltFusion/DebugViewPP) since it offers some nice filtering options and other convenience features.
+## Default log level
 
-Alternatively, you can also enable [logging to file](Command-Line-Arguments.md#-log-to-file-value) or [raise the log level](Command-Line-Arguments.md#-log-level-value) to get even more details.
+The default log level is **`info`**. Debug and trace messages (including output from the `log()` callback in [Inja templates](Inja-Templates.md)) require explicitly raising the level to `debug` or lower via [`--log-level debug`](Command-Line-Arguments.md#-log-level-value).
+
+## Observing logs
+
+To observe the live `OutputDebugString` output I recommend using the tool [DebugView++](https://github.com/CobaltFusion/DebugViewPP) since it offers nice filtering options and other convenience features.
+
+Alternatively, you can also enable [logging to file](Command-Line-Arguments.md#-log-to-file-value) to persist the output, or [raise the log level](Command-Line-Arguments.md#-log-level-value) to get more details.
 
 ## Examples
 

--- a/docs/projects/Vicius/Product-Detection.md
+++ b/docs/projects/Vicius/Product-Detection.md
@@ -14,7 +14,7 @@ The value to query must be a string of of type [`REG_SZ`](https://learn.microsof
 
 Field | Description | Mandatory
 ---|---|---
-`view` | The [Alternate Registry View](https://learn.microsoft.com/en-us/windows/win32/winprog64/accessing-an-alternate-registry-view) to use if a 32-Bit updater process needs to read a 64-Bit key and vice versa. Only useful if the updater architecture differs from the installed product architecture (e.g. the product is a 32-Bit installation and the updater is a 64-Bit build). In most cases it should be avoided to mix architectures and simply use the value `Default`. Possible values are: <ul><li>`Default` - Doesn't alter default behaviour.</li><li>`WOW64_64KEY` - Access a 64-bit key from either a 32-bit or 64-bit application.</li><li>`WOW64_32KEY` - Access a 32-bit key from either a 32-bit or 64-bit application.</li></ul> | Yes
+`view` | The [Alternate Registry View](https://learn.microsoft.com/en-us/windows/win32/winprog64/accessing-an-alternate-registry-view) to use if a 32-Bit updater process needs to read a 64-Bit key and vice versa. Only useful if the updater architecture differs from the installed product architecture (e.g. the product is a 32-Bit installation and the updater is a 64-Bit build). In most cases it should be avoided to mix architectures and simply use the value `Default`. Possible values are: <ul><li>`Default` - Doesn't alter default behaviour. **(Default if omitted)**</li><li>`WOW64_64KEY` - Access a 64-bit key from either a 32-bit or 64-bit application.</li><li>`WOW64_32KEY` - Access a 32-bit key from either a 32-bit or 64-bit application.</li></ul> | No
 `hive` | The [hive](https://learn.microsoft.com/en-us/troubleshoot/windows-server/performance/windows-registry-advanced-users) to search in. Possible values are: <ul><li>`HKCU` for `HKEY_CURRENT_USER`</li><li>`HKLM` for `HKEY_LOCAL_MACHINE`</li><li>`HKCR` for `HKEY_CLASSES_ROOT`</li></ul> | Yes
 `key` | The sub-key path under the specified hive. For example `SOFTWARE\Nefarius Software Solutions e.U.\HidHide`. | Yes
 `value` | The `REG_SZ` (string) value to read. For example `Version`. | Yes
@@ -68,9 +68,11 @@ Field | Description | Mandatory
 
 !!! important "Access to data in your expression"
     You can use three pre-defined variables in your template/expression:  
-    - `merged` holds the shared configuration state of the client  
-    - `remote` holds the server response and  
-    - `parameters` holds what the server provided in the `data` field.
+    - `merged` holds the shared configuration state of the client.  
+    - `remote` holds the server response.  
+    - `parameters` holds the contents of the `data` field from the **detection configuration** (i.e. the `data` key in the same object as `input`). Depending on the active `authority` setting, this may come from the local configuration file or from the server-provided detection config. It is not unconditionally "what the server provided".
+
+    In addition, all [Inja template callbacks](Inja-Templates.md) (`envar`, `regval`, `inival`, `productBy`, `versionEq`, `versionGt`, `versionLt`, `exists`, `log`) are available inside the expression.
 
 ### `FixedVersion`
 
@@ -81,3 +83,22 @@ Overrides the detected version with a fixed version string.
 Field | Description | Mandatory
 ---|---|---
 `version` | The version string. | Yes
+
+## Release-side detection fields
+
+Some detection methods compare a locally detected value against a reference provided on the **release object** in the [remote configuration](Remote-Configuration.md), rather than (or in addition to) the detection config itself.
+
+Field | Used by | Description
+---|---|---
+`detectionVersion` | `RegistryValue`, `FileVersion`, `FixedVersion` | The expected version string for this release. If omitted, the release's `version` field is used as the fallback.
+`detectionSize` | `FileSize` | The expected file size in bytes for this release.
+`detectionChecksum` | `FileChecksum` | A [`ChecksumParameters`](Download-Integrity.md) object (`checksum` + `checksumAlg`) specifying the expected hash of the locally installed file for this release.
+
+## Command-line overrides
+
+Two CLI flags bypass whatever detection method is configured:
+
+Flag | Effect
+---|---
+[`--local-version <version>`](Command-Line-Arguments.md#--local-version-version) | Overrides the detected local version only when no detection method is configured in either the local or remote configuration.
+[`--force-local-version <version>`](Command-Line-Arguments.md#--force-local-version-version) | Unconditionally overrides the detected version, ignoring any detection method in local or remote configuration.

--- a/docs/projects/Vicius/Remote-Configuration.md
+++ b/docs/projects/Vicius/Remote-Configuration.md
@@ -1,6 +1,12 @@
 # Remote Configuration
 
-The updater expects a JSON response from the update server; you can find various implementation details and examples below. The updater as a client is quite resilient; every property/field marked as optional/nullable can be omitted entirely in the response. In theory you don't even need to provide any releases in the response, just make it an empty array and you're good to go.
+The updater expects a JSON response from the update server; you can find various implementation details and examples below.
+
+!!! warning "Empty `releases` is not safe"
+    Serving an empty `releases` array (`"releases": []`) is **not** a no-op. The updater will successfully parse the response but will then fail product version detection (it needs at least one release to compare against), and exit with code `105` (`NV_E_PRODUCT_DETECTION`). If you want to signal "nothing to do", remove the `emergencyUrl` and use a release whose version matches what you expect users to have installed.
+
+!!! note "Optional vs. required fields"
+    Top-level `instance` and `shared` objects are optional and can be omitted. However, each entry in the `releases` array has required fields (`name`, `version`, `summary`, `publishedAt`, `downloadUrl`). Omitting required release fields may cause parsing or version-comparison failures.
 
 ## JSON Schema
 

--- a/docs/projects/Vicius/Server-Discovery.md
+++ b/docs/projects/Vicius/Server-Discovery.md
@@ -6,7 +6,19 @@ The single most important setting that *at least* needs to be customized is the 
 
 ### Make your own custom build
 
-Check out the projects source code, edit the `NV_API_URL_TEMPLATE` value in `CustomizeMe.h` and build your very own copy of the updater. Done!
+Check out the project's source code, edit the `NV_API_URL_TEMPLATE` value in `CustomizeMe.h` and build your very own copy of the updater. Done!
+
+The default templates in `CustomizeMe.h` are:
+
+```cpp
+// Release builds
+#define NV_API_URL_TEMPLATE "https://vicius.api.nefarius.systems/api/{}/updates.json"
+
+// Debug builds
+#define NV_API_URL_TEMPLATE "http://localhost:5200/api/{}/updates.json"
+```
+
+The `{}` placeholder is automatically replaced with `manufacturer/product` (extracted from the executable file name via `filenameRegex`) or with `manufacturer/product/channel` when a channel is set (via [`--channel`](Command-Line-Arguments.md#--channel-value) or the `channel` field in the [local configuration](Local-Configuration.md#notable-instance-fields)).
 
 !!! note "Consider signing your executable"
     Consider signing the resulting binary with your (company's) code signing certificate.
@@ -30,9 +42,8 @@ Assuming your final updater executable name being `nefarius_HidHide_Updater.exe`
 
 ### Edit the string table resource
 
-!!! warning "Can be disabled during build"
-    This method will **not work** if the updater binary is built with  
-    `NV_FLAGS_NO_SERVER_URL_RESOURCE` set in `CustomizeMe.h`!
+!!! warning "Disabled in stock builds"
+    `NV_FLAGS_NO_SERVER_URL_RESOURCE` is **defined (active) by default** in `CustomizeMe.h`. This means the string table resource method is disabled unless you explicitly comment it out. Stock release binaries built from the repository without modification will not read string resource `105` and will use the compiled-in URL template instead.
 
 If you wish to both avoid compiling your own binary and shipping a configuration file, you can use [Resource Hacker](https://angusj.com/resourcehacker/) on the updater executable and edit the string table entry `105` as seen below:
 
@@ -41,3 +52,14 @@ If you wish to both avoid compiling your own binary and shipping a configuration
 !!! warning "Doing so will break the executable signature"
     If you use this method, beware that this will invalidate the signature of the executable.  
     Consider re-signing the resulting binary, if possible or avoid this method altogether.
+
+## Advanced local configuration options
+
+When using the [local configuration file](Local-Configuration.md) approach, additional `instance` fields give you fine-grained control over server discovery:
+
+- **`fallbackServerUrlTemplates`** — an array of additional URLs tried in order if the primary URL fails.
+- **`filenameRegex`** — override the regex used to extract `manufacturer` and `product` from the executable name. Useful if your binary doesn't follow the default `manufacturer_product_Updater` naming convention.
+- **`channel`** — sets an update channel name that is inserted as the third segment of the URL template (`manufacturer/product/channel`). Can also be supplied at runtime via [`--channel`](Command-Line-Arguments.md#--channel-value).
+- **`network`** — configures proxy, DNS-over-HTTPS, and IP-family preferences.
+
+See [Local Configuration — Notable instance fields](Local-Configuration.md#notable-instance-fields) for full details and available sub-fields.

--- a/docs/projects/Vicius/Server-Discovery.md
+++ b/docs/projects/Vicius/Server-Discovery.md
@@ -59,7 +59,7 @@ When using the [local configuration file](Local-Configuration.md) approach, addi
 
 - **`fallbackServerUrlTemplates`** — an array of additional URLs tried in order if the primary URL fails.
 - **`filenameRegex`** — override the regex used to extract `manufacturer` and `product` from the executable name. Useful if your binary doesn't follow the default `manufacturer_product_Updater` naming convention.
-- **`channel`** — sets an update channel name that is inserted as the third segment of the URL template (`manufacturer/product/channel`). Can also be supplied at runtime via [`--channel`](Command-Line-Arguments.md#--channel-value).
+- **`channel`** — sets an update channel name that is inserted as the third segment of the URL template (`manufacturer/product/channel`). It can also be supplied at runtime via [`--channel`](Command-Line-Arguments.md#--channel-value).
 - **`network`** — configures proxy, DNS-over-HTTPS, and IP-family preferences.
 
 See [Local Configuration — Notable instance fields](Local-Configuration.md#notable-instance-fields) for full details and available sub-fields.

--- a/docs/projects/Vicius/Setup-Exit-Codes.md
+++ b/docs/projects/Vicius/Setup-Exit-Codes.md
@@ -2,6 +2,12 @@
 
 When the updater runs the downloaded setup process, it captures the exit code the setup returns and decides whether the installation succeeded or failed. By default only exit code `0` is treated as success.
 
+!!! note "ZIP archive updates bypass exit code checking"
+    For ZIP-based updates the updater performs file copy operations directly and does not launch an external setup executable. Success is determined by whether the extraction and copy succeeded, not by an exit code. The `exitCode` configuration has no effect on ZIP updates.
+
+!!! note "Setup launch failures"
+    If the setup process cannot be launched at all (e.g. the downloaded file is missing or not executable), the updater exits with code `109` (`NV_E_SETUP_FAILED`) rather than consulting the exit-code configuration.
+
 The `exitCode` object in the [remote configuration](Remote-Configuration.md) lets you control this behaviour. It can be placed either on the `instance` object (applies to every release) or directly on an individual release entry (takes precedence over the instance-level setting when both are present).
 
 ## Basic fields
@@ -35,7 +41,7 @@ The `messages` field is an object whose **keys are exit codes expressed as decim
 
 Field | Type | Required | Description
 ---|---|---|---
-`message` | `string` | Yes | Text shown to the user when this exit code is encountered.
+`message` | `string` | Yes | Text shown to the user when this exit code is encountered. An empty string (`""`) is treated the same as no entry — no custom screen is shown and the updater falls back to default behavior (success closes silently; failure shows the generic error text).
 `isSuccess` | `bool` | No | When `true`, this exit code is treated as a success condition even if it is absent from `successCodes`.
 `helpUrl` | `string` | No | URL opened in the browser when the user clicks the help button shown alongside the message.
 `buttonText` | `string` | No | Custom label for the help button. Defaults to `"Open help page"` when omitted.

--- a/docs/projects/Vicius/Setup-Exit-Codes.md
+++ b/docs/projects/Vicius/Setup-Exit-Codes.md
@@ -48,9 +48,9 @@ Field | Type | Required | Description
 
 ### UI behaviour
 
-**Success path** — when the setup exits with a code that resolves to success (via `skipCheck`, `successCodes`, or `isSuccess: true` in the map) and a `messages` entry exists for that code, the updater displays a success screen with the configured message text and an optional help button. The user must click **Finish** to close the updater. Without a message entry the updater closes silently, as it always has.
+**Success path** — when the setup exits with a code that resolves to success (via `skipCheck`, `successCodes`, or `isSuccess: true` in the map) and a `messages` entry exists for that code with a non-empty `message` string, the updater displays a success screen with the configured message text and an optional help button. The user must click **Finish** to close the updater. If no entry exists, or the entry's `message` is an empty string, the updater closes silently, as it always has.
 
-**Failure path** — when the setup exits with a non-success code and a `messages` entry exists for it, the updater shows the distributor-supplied message and optional help button instead of the generic "unexpected exit code" text, allowing you to provide more actionable guidance for known failure modes.
+**Failure path** — when the setup exits with a non-success code and a `messages` entry exists for it with a non-empty `message` string, the updater shows the distributor-supplied message and optional help button instead of the generic "unexpected exit code" text, allowing you to provide more actionable guidance for known failure modes. If no entry exists, or the entry's `message` is empty, the generic error text is shown.
 
 ## Examples
 

--- a/docs/projects/Vicius/Signature-Verification.md
+++ b/docs/projects/Vicius/Signature-Verification.md
@@ -175,17 +175,23 @@ Sign your updated manifest with the **same Ed25519 key**. No redeployment of the
 
 When manifest signing is enabled (`NV_MANIFEST_PUBLIC_KEY` defined), the updater also enforces a monotonically increasing `manifestVersion` field.
 
-Add an unsigned integer to your manifest's `instance` block:
+Add an unsigned integer as a **root-level** field of your manifest JSON:
 
 ```json
 {
-    "instance": {
-        "manifestVersion": 42
-    }
+    "manifestVersion": 42,
+    "instance": { ... },
+    "releases": [ ... ]
 }
 ```
 
-If the server delivers a manifest whose `manifestVersion` is lower than the last successfully processed version on that client, the update check is rejected with error code `119`. This prevents an attacker from replaying an older, legitimately signed manifest that contained a vulnerable release.
+!!! warning "`manifestVersion` is a root-level field"
+    The field must be at the top level of the JSON object, not nested inside `instance`. Nesting it under `instance` will cause it to be ignored.
+
+If the server delivers a manifest whose `manifestVersion` is lower than the last successfully processed version on that client, the update check is rejected. The last seen version is persisted in the registry at `HKCU\Software\<manufacturer>\<product>\Vicius\ManifestVersion`. A registry failure (e.g. write permission error) is non-fatal — the updater logs a warning and continues.
+
+!!! note "Current runtime behavior"
+    A manifest rollback detection failure causes `RequestUpdateInfo()` to fail, which the process reports as exit code `104` (`NV_E_SERVER_RESPONSE`). Exit code `119` (`NV_E_MANIFEST_DOWNGRADE`) is reserved for this condition but is not yet individually emitted.
 
 !!! note "Only active when `NV_MANIFEST_PUBLIC_KEY` is defined"
     The downgrade check is only executed when manifest signing is enabled. Without a trusted signature, the manifest version field cannot be trusted.
@@ -196,7 +202,7 @@ If the server delivers a manifest whose `manifestVersion` is lower than the last
 
 Passing `--strict-verification` on the command line activates a client-side hardened mode with three effects:
 
-1. **Checksum required** — if the selected release has no `checksum` field, the update is rejected immediately (exit code `115`).
+1. **Checksum required** — if the selected release has no `checksum` field, the update is rejected *after download* during the integrity check phase (exit code `116`). The rejection happens post-download, not before.
 2. **Server cannot downgrade security** — the server-provided `signatureVerificationMode`, `signaturePolicy`, `signatureStrategy`, and `signatureConfig` fields in `shared` are ignored. Only the settings already baked into the local configuration or forced by the build take effect.
 3. **Minimum security floor** — if the merged `signatureVerificationMode` is `WhenPresent` or `Disabled`, it is silently upgraded to `Required`; if `signaturePolicy` is `Relaxed`, it is upgraded to `Strict`.
 
@@ -204,14 +210,18 @@ See [Command Line Arguments](Command-Line-Arguments.md#--strict-verification) fo
 
 ---
 
+## Notes on ZIP / non-PE payloads
+
+ZIP archives and other non-executable payloads cannot carry an Authenticode signature. When the updater attempts to verify such a file, the Windows trust infrastructure returns `TRUST_E_SUBJECT_FORM_UNKNOWN`, which the updater treats as "unsigned". Under the default `WhenPresent` mode this is accepted; under `Required` mode or `--strict-verification` it causes the update to be rejected with exit code `116`. If you distribute ZIP archives, keep `signatureVerificationMode` at `WhenPresent` or `Disabled` (and rely on checksums instead), or sign a wrapper executable.
+
 ## Related exit codes
 
 Code | Description
 ---|---
-`115` | Download checksum mismatch (computed hash differs from `release.checksum`).
-`116` | Setup Authenticode signature is invalid or the chain could not be validated.
-`117` | Publisher certificate does not match the configured pin.
-`118` | Manifest Ed25519 signature is invalid or the `.minisig` sidecar could not be fetched.
-`119` | Manifest version rollback detected; the server delivered an older manifest version.
+`104` | Manifest processing failure — covers manifest Ed25519 verification failure (code `118`) and manifest version rollback (code `119`), which currently surface as this code.
+`116` | All post-download integrity/authenticity failures — covers checksum mismatch (code `115`), invalid or untrusted Authenticode chain, publisher pin mismatch (code `117`), and a missing `checksum` field when `--strict-verification` is active.
+
+!!! note "Granular codes 115, 117, 118, 119 are reserved"
+    These codes are defined in the source but are not yet individually emitted. All post-download failures report `116`; all manifest failures report `104`. See the [full exit code reference](Exit-Codes.md#reserved--not-yet-individually-emitted) for details.
 
 See [Exit Codes](Exit-Codes.md) for the full list.

--- a/docs/projects/Vicius/Terminate-Process-before-Update.md
+++ b/docs/projects/Vicius/Terminate-Process-before-Update.md
@@ -9,12 +9,18 @@ This is the intended pattern when the updater is launched directly **by** the pr
 
 ## Handle requirements
 
-The value passed to `--terminate-process-before-update` is a Win32 `HANDLE` expressed as a **decimal integer**. The updater validates the handle at startup and silently disables the feature (logging an error) for any of the following:
+The value passed to `--terminate-process-before-update` is a Win32 `HANDLE` expressed as a **decimal integer**. The updater performs a limited validation at startup and silently disables the feature (logging an error) if validation fails.
 
-- **MUST** be a real Win32 `HANDLE` — a **PID is not a handle**. If you only have a PID, obtain a handle first with `OpenProcess()`.
-- The handle should have at least `PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION` permissions. `PROCESS_QUERY_LIMITED_INFORMATION` is needed because the updater calls `GetProcessId()` to confirm the handle is valid. The updater does not verify these permissions at startup — an insufficient-permissions handle will fail only when `TerminateProcess` is actually called.
-- The handle should be inheritable (`bInheritHandle = TRUE`). This is not checked at startup; without it the handle will be invalid in the child process.
-- **MUST NOT** be a pseudo-handle (e.g. the raw return value of `GetCurrentProcess()`). Pseudo-handles are per-process constants whose numeric values are meaningless in any other process. The updater explicitly rejects them.
+**Checked at startup** — the feature is disabled immediately if:
+
+- The value is zero (no handle provided).
+- The handle is a pseudo-handle (e.g. the raw return value of `GetCurrentProcess()`). Pseudo-handles are per-process constants whose numeric values are meaningless in any other process.
+- `GetProcessId()` on the handle fails — this confirms it is a valid, open kernel handle. A **PID is not a handle**; if you only have a PID, obtain a real handle first with `OpenProcess()`.
+
+**Not checked at startup — may fail at runtime** — the updater does not verify:
+
+- **Permissions**: the handle should have at least `PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION` access rights. `PROCESS_QUERY_LIMITED_INFORMATION` is what makes the startup `GetProcessId()` call succeed; `PROCESS_TERMINATE` is required when `TerminateProcess` is called immediately before the setup runs. An under-privileged handle passes startup validation but will fail at that point.
+- **Inheritability**: the handle must be inheritable (`bInheritHandle = TRUE`) so the operating system copies it into the child updater process. This is not validated at startup; a non-inheritable handle will be unusable in the child process even though startup succeeds.
 
 ## Step 1 — Create a real, inheritable handle
 

--- a/docs/projects/Vicius/Terminate-Process-before-Update.md
+++ b/docs/projects/Vicius/Terminate-Process-before-Update.md
@@ -12,8 +12,8 @@ This is the intended pattern when the updater is launched directly **by** the pr
 The value passed to `--terminate-process-before-update` is a Win32 `HANDLE` expressed as a **decimal integer**. The updater validates the handle at startup and silently disables the feature (logging an error) for any of the following:
 
 - **MUST** be a real Win32 `HANDLE` — a **PID is not a handle**. If you only have a PID, obtain a handle first with `OpenProcess()`.
-- **MUST** have `PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION` permissions — `PROCESS_QUERY_LIMITED_INFORMATION` is required because the updater calls `GetProcessId()` on the handle to validate it.
-- **MUST** be inheritable (`bInheritHandle = TRUE`) and owned by the updater's parent process.
+- The handle should have at least `PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION` permissions. `PROCESS_QUERY_LIMITED_INFORMATION` is needed because the updater calls `GetProcessId()` to confirm the handle is valid. The updater does not verify these permissions at startup — an insufficient-permissions handle will fail only when `TerminateProcess` is actually called.
+- The handle should be inheritable (`bInheritHandle = TRUE`). This is not checked at startup; without it the handle will be invalid in the child process.
 - **MUST NOT** be a pseudo-handle (e.g. the raw return value of `GetCurrentProcess()`). Pseudo-handles are per-process constants whose numeric values are meaningless in any other process. The updater explicitly rejects them.
 
 ## Step 1 — Create a real, inheritable handle
@@ -75,4 +75,7 @@ CreateProcessW(
 
     `TerminateProcess` returns before the process has fully exited. The operating system does not guarantee that all file handles held by the process are released by the time the setup starts. If the setup fails due to locked files immediately after termination, a brief wait or retry in the installer itself is the appropriate remedy.
 
-If the `TerminateProcess` call fails for any reason, the updater aborts the update and exits with code [`111`](Exit-Codes.md).
+If the `TerminateProcess` call fails for any reason, the updater aborts the update. The failure is reported as exit code `109` (`NV_E_SETUP_FAILED`). Exit code `111` (`NV_E_TERMINATE_PROCESS_BEFORE_UPDATE_FAILED`) is reserved for this condition but is not yet individually emitted.
+
+!!! note "No user confirmation in `--silent-update` mode"
+    When the updater is launched with [`--silent-update`](Command-Line-Arguments.md#--silent-update), the process is terminated without any user-facing prompt. Ensure the calling application saves state and notifies the user appropriately before launching the updater in this mode.

--- a/docs/projects/Vicius/ZIP-Archives.md
+++ b/docs/projects/Vicius/ZIP-Archives.md
@@ -24,10 +24,13 @@ If you launch the updater from your executable, you will probably want to use th
 
 If you include the updater in your zip, you will need to handle updating the updater; there are two ways to do this:
 
-- **Recommended**: set the `runAsTemporaryCopy` option to `true`
-- set the updater disposition to `CreateIfAbsent` (see below)
+- **Recommended**: set the `runAsTemporaryCopy` option to `true` in the `shared` section of your [local](Local-Configuration.md) or remote configuration (not on the release object).
+- set the updater disposition to `CreateIfAbsent` (see below).
 
 If you do not do either, installing your update will fail when attempting to replace the updater, as the file will be in use.
+
+!!! note "Two-phase extraction"
+    ZIP archives are first extracted to a temporary directory, and then the files are copied to the destination (the directory containing the watched executable). Zip-slip attacks (paths that escape the destination directory via `..` sequences) are blocked — such entries are skipped with a warning.
 
 ## Customizing Behavior
 
@@ -46,24 +49,13 @@ You can change the default with the `zipExtractDefaultFileDisposition` configura
 
 ## Running the setup as Administrator
 
-If the ZIP-based update process needs elevated privileges (e.g. to write to `Program Files`), add `runAsAdmin` to the release:
+!!! warning "`runAsAdmin` has no effect on ZIP file-copy updates"
+    For ZIP archives, the update process consists entirely of file copy operations — there is no separate setup executable to launch with elevated privileges. The `runAsAdmin` field is ignored on the ZIP extraction path. Elevation only applies when the downloaded payload is an executable (MSI, EXE, or similar). If your ZIP needs to write to `Program Files`, run the updater itself with elevated privileges via the calling process.
 
-```json
-{
-    "releases": [
-        {
-            "name": "My Tool",
-            "version": "2024.7.18",
-            "downloadUrl": "https://example.com/example.zip",
-            "runAsAdmin": true
-        }
-    ]
-}
-```
+!!! warning "Gating condition for `runAsAdmin`"
+    Even for executable payloads, `runAsAdmin` is only honored when `signatureVerificationMode` is `Required` **or** `--strict-verification` is active. Under the default `WhenPresent` mode the field is silently ignored. This prevents a compromised server from abusing the elevation mechanism.
 
-When `true`, the extracted setup is launched via the `runas` shell verb, which triggers a UAC elevation prompt. This field is also available at the `instance` level to set it as a default for all releases.
-
-You can change the default with the `zipExtractDefaultFileDisposition` configuration option, or change it for specific paths with the `zipExtractFileDispositionOverrides` key; for example:
+You can change the default with the `zipExtractDefaultFileDisposition` configuration option, or change it for specific paths with the `zipExtractFileDispositionOverrides` key. Note that `DeleteIfPresent` entries are processed in a **second pass** after all files have been extracted — they only affect paths listed in `zipExtractFileDispositionOverrides`, not the default disposition. Example:
 
 ```json
 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified command-line flag behavior, including silent/headless prompts, `--temporary` incompatibilities, `--strict-verification` post-download rejection timing, and updated exit-code meanings (notably `116` for integrity/auth failures).
  * Updated checksum algorithm support (only `SHA256`/`SHA1`; `MD5` not supported for verification) and verification/rollback documentation (including root-level `manifestVersion`).
  * Expanded guidance across logging, emergency URL timing, process termination outcomes, server discovery templates, remote response contracts, product detection fields, and ZIP update/admin-elevation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->